### PR TITLE
Require `Async` version 2.31 or later.

### DIFF
--- a/async-limiter.gemspec
+++ b/async-limiter.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 3.2"
 	
-	spec.add_dependency "async"
+	spec.add_dependency "async", ">= 2.31"
 end


### PR DESCRIPTION
Using `Async` version 2.30.0 results in the following exception:

```ruby
LoadError: cannot load such file -- async/deadline
```

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
